### PR TITLE
Add appindicator support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.deluge_torrent.deluge.yaml
+++ b/org.deluge_torrent.deluge.yaml
@@ -11,9 +11,12 @@ finish-args:
   - --share=ipc
   - --share=network
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-download
 
 modules:
+
+- shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
 
 - name: boost
   cleanup: [


### PR DESCRIPTION
This change enables Deluge's appindicator support for system tray icons.