### PR TITLE
fix: socket=fallback-x11 -> socket=x11

### DIFF
--- a/org.deluge_torrent.deluge.yaml
+++ b/org.deluge_torrent.deluge.yaml
@@ -7,7 +7,7 @@ rename-icon: deluge
 
 finish-args:
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --share=ipc
   - --share=network
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
Doesn't start with `socket=fallback-x11` in Wayland.

```
❯ flatpak run org.deluge_torrent.deluge
Unable to initialize gettext/locale!
'ngettext'
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/deluge/i18n/util.py", line 118, in setup_translation
    builtins.__dict__['_n'] = builtins.__dict__['ngettext']
KeyError: 'ngettext'
Traceback (most recent call last):
  File "/app/bin/deluge-gtk", line 33, in <module>
    sys.exit(load_entry_point('deluge==2.0.3', 'gui_scripts', 'deluge-gtk')())
  File "/app/lib/python3.8/site-packages/deluge/ui/gtk3/__init__.py", line 63, in start
    Gtk().start()
  File "/app/lib/python3.8/site-packages/deluge/ui/gtk3/__init__.py", line 43, in start
    from .gtkui import GtkUI
  File "/app/lib/python3.8/site-packages/deluge/ui/gtk3/gtkui.py", line 27, in <module>
    from twisted.internet import defer, gtk3reactor
  File "/app/lib/python3.8/site-packages/twisted/internet/gtk3reactor.py", line 37, in <module>
    raise ImportError(
ImportError: Gtk3 requires X11, and no DISPLAY environment variable is set
```