### PR TITLE
Update runtime to 22.08

### DIFF
--- a/org.deluge_torrent.deluge.yml
+++ b/org.deluge_torrent.deluge.yml
@@ -1,6 +1,6 @@
 app-id: org.deluge_torrent.deluge
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: deluge-gtk
 rename-icon: deluge

--- a/org.deluge_torrent.deluge.yml
+++ b/org.deluge_torrent.deluge.yml
@@ -230,8 +230,8 @@ modules:
   - python3 setup.py install --prefix=/app --root=/
   sources:
   - type: archive
-    url: https://files.pythonhosted.org/packages/f4/d5/a6c19dcbcbc267aca376558797f036d9bcdff344c9f785fe7d0fe9a5f2a7/setuptools-41.4.0.zip
-    sha256: 7eae782ccf36b790c21bde7d86a4f303a441cd77036b25c559a602cf5186ce4d
+    url: https://files.pythonhosted.org/packages/f8/b8/fe1dfb94342906c65acfda3d8f35984c87e0511bf574942c22aed756d0f6/setuptools-65.6.2.tar.gz 
+    sha256: 41fa68ecac9e099122990d7437bc10683b966c32a591caa2824dffcffd5dea7a
 
 - name: setuptools-scm
   buildsystem: simple
@@ -284,8 +284,8 @@ modules:
   - python3 setup.py install --prefix=/app --root=/
   sources:
   - type: archive
-    url: https://files.pythonhosted.org/packages/82/a8/1e0f86ae3f13f7ce260e9f782764c16559917f24382c74edfb52149897de/numpy-1.20.2.zip
-    sha256: 878922bf5ad7550aa044aa9301d417e2d3ae50f0f577de92051d739ac6096cee
+    url: https://files.pythonhosted.org/packages/42/38/775b43da55fa7473015eddc9a819571517d9a271a9f8134f68fb9be2f212/numpy-1.23.5.tar.gz
+    sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a
 
 - name: twisted
   buildsystem: simple

--- a/org.deluge_torrent.deluge.yml
+++ b/org.deluge_torrent.deluge.yml
@@ -33,8 +33,8 @@ modules:
   buildsystem: simple
   sources:
   - type: archive
-    url: https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2
-    sha256: f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41
+    url: https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2
+    sha256: 1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0 
   build-commands:
   - ./bootstrap.sh --prefix="${FLATPAK_DEST}" --with-python=python3 
   - ./b2 stage  -j $FLATPAK_BUILDER_N_JOBS variant=release threading=multi link=shared debug-symbols=off

--- a/org.deluge_torrent.deluge.yml
+++ b/org.deluge_torrent.deluge.yml
@@ -49,8 +49,8 @@ modules:
     - -Dboost-python-module-name=python
   sources:
     - type: archive
-      url: https://github.com/arvidn/libtorrent/releases/download/v1.2.12/libtorrent-rasterbar-1.2.12.tar.gz
-      sha256: c3744ac9fa41f6e6ebf79538a2ea678df76a2cbbaf3ac6ae2c05455314e5cce8
+      url: https://github.com/arvidn/libtorrent/releases/download/v1.2.18/libtorrent-rasterbar-1.2.18.tar.gz
+      sha256: fef2b6817de4e6d960e019c27f21daf27bc2468a81d9e028a19d45d61456fa72
 
 ## Python3 modules
 - name: wheel


### PR DESCRIPTION
I built locally and boost not compiled, with runtime 22.08, updating boost to v1.80.0 and also update the libtorrent to latest (v1.2.18)
