### PR TITLE
update boost url

### DIFF
--- a/org.deluge_torrent.deluge.yml
+++ b/org.deluge_torrent.deluge.yml
@@ -36,7 +36,7 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2
+        url: https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2
         sha256: 6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
     build-commands:
       - ./bootstrap.sh --prefix="${FLATPAK_DEST}" --with-python=python3


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
